### PR TITLE
Improve math challenge input handling

### DIFF
--- a/website.html
+++ b/website.html
@@ -199,6 +199,13 @@
             gap: 15px;
             margin-bottom: 25px;
         }
+        .answer-input {
+            padding: 15px;
+            font-size: 1.1rem;
+            border: 2px solid #e0e0e0;
+            border-radius: 10px;
+            width: 100%;
+        }
 
         .option {
             background: #f8f9fa;
@@ -482,31 +489,31 @@
         // Challenge data
         var challenges = {
             math: [
-                { question: "כמה זה <span class='math-expression'>25 + 17</span>?", options: ["42", "32", "45", "41"], correct: 0 },
-                { question: "מה התוצאה של <span class='math-expression'>8 × 7</span>?", options: ["54", "56", "64", "58"], correct: 1 },
-                { question: "כמה זה <span class='math-expression'>144 ÷ 12</span>?", options: ["12", "14", "10", "16"], correct: 0 },
-                { question: "איזה מספר חסר ברצף?<div class='math-expression'>3, 6, 9, ?, 15</div>", options: ["11", "12", "13", "14"], correct: 1 },
-                { question: "מה שווה <span class='math-expression'>1/2 + 1/4</span>?", options: ["2/6", "3/4", "1/6", "2/8"], correct: 1 },
-                { question: "כמה זה <span class='math-expression'>15 × 4</span>?", options: ["60", "55", "65", "50"], correct: 0 },
-                { question: "מה התוצאה של <span class='math-expression'>100 - 37</span>?", options: ["63", "73", "67", "77"], correct: 0 },
-                { question: "כמה זה <span class='math-expression'>36 ÷ 6</span>?", options: ["5", "6", "7", "8"], correct: 1 },
-                { question: "איזה מספר הכי גדול?<div class='math-expression'>0.5, 1/3, 2/5, 0.7</div>", options: ["0.5", "1/3", "2/5", "0.7"], correct: 3 },
-                { question: "מה התוצאה של <span class='math-expression'>9 × 6</span>?", options: ["54", "56", "52", "58"], correct: 0 },
-                { question: "כמה זה <span class='math-expression'>200 - 85</span>?", options: ["115", "125", "105", "135"], correct: 0 },
-                { question: "איזה מספר חסר ברצף?<div class='math-expression'>2, 4, 8, 16, ?</div>", options: ["24", "32", "20", "28"], correct: 1 },
-                { question: "מה שווה <span class='math-expression'>3/4</span> של <span class='math-expression'>20</span>?", options: ["15", "12", "18", "16"], correct: 0 },
-                { question: "כמה זה <span class='math-expression'>13 × 3</span>?", options: ["39", "36", "42", "33"], correct: 0 },
-                { question: "מה התוצאה של <span class='math-expression'>81 ÷ 9</span>?", options: ["8", "9", "10", "7"], correct: 1 },
-                { question: "איזה מספר זוגי?<div class='math-expression'>17, 23, 34, 41</div>", options: ["17", "23", "34", "41"], correct: 2 },
-                { question: "כמה זה <span class='math-expression'>45 + 28</span>?", options: ["73", "63", "83", "67"], correct: 0 },
-                { question: "מה התוצאה של <span class='math-expression'>7 × 8</span>?", options: ["54", "56", "64", "48"], correct: 1 },
-                { question: "כמה זה <span class='math-expression'>120 ÷ 8</span>?", options: ["15", "12", "18", "14"], correct: 0 },
-                { question: "איזה מספר חסר ברצף?<div class='math-expression'>5, 10, 20, 40, ?</div>", options: ["60", "80", "70", "100"], correct: 1 },
-                { question: "מה שווה <span class='math-expression'>2/3 + 1/6</span>?", options: ["3/9", "5/6", "4/9", "7/12"], correct: 1 },
-                { question: "כמה זה <span class='math-expression'>16 × 5</span>?", options: ["80", "75", "85", "70"], correct: 0 },
-                { question: "מה התוצאה של <span class='math-expression'>150 - 67</span>?", options: ["83", "93", "73", "87"], correct: 0 },
-                { question: "כמה זה <span class='math-expression'>72 ÷ 8</span>?", options: ["8", "9", "10", "7"], correct: 1 },
-                { question: "איזה מספר אי-זוגי?<div class='math-expression'>24, 36, 45, 58</div>", options: ["24", "36", "45", "58"], correct: 2 },
+                { question: "כמה זה <span class='math-expression'>25 + 17</span>?", answer: "42", input: true },
+                { question: "מה התוצאה של <span class='math-expression'>8 × 7</span>?", answer: "56", input: true },
+                { question: "כמה זה <span class='math-expression'>144 ÷ 12</span>?", answer: "12", input: true },
+                { question: "איזה מספר חסר ברצף?<div class='math-expression'>3, 6, 9, ?, 15</div>", answer: "12", input: true },
+                { question: "מה שווה <span class='math-expression'>1/2 + 1/4</span>?", answer: "3/4", input: true },
+                { question: "כמה זה <span class='math-expression'>15 × 4</span>?", answer: "60", input: true },
+                { question: "מה התוצאה של <span class='math-expression'>100 - 37</span>?", answer: "63", input: true },
+                { question: "כמה זה <span class='math-expression'>36 ÷ 6</span>?", answer: "6", input: true },
+                { question: "איזה מספר הכי גדול?<div class='math-expression'>0.5, 1/3, 2/5, 0.7</div>", answer: "0.7", input: true },
+                { question: "מה התוצאה של <span class='math-expression'>9 × 6</span>?", answer: "54", input: true },
+                { question: "כמה זה <span class='math-expression'>200 - 85</span>?", answer: "115", input: true },
+                { question: "איזה מספר חסר ברצף?<div class='math-expression'>2, 4, 8, 16, ?</div>", answer: "32", input: true },
+                { question: "מה שווה <span class='math-expression'>3/4</span> של <span class='math-expression'>20</span>?", answer: "15", input: true },
+                { question: "כמה זה <span class='math-expression'>13 × 3</span>?", answer: "39", input: true },
+                { question: "מה התוצאה של <span class='math-expression'>81 ÷ 9</span>?", answer: "9", input: true },
+                { question: "איזה מספר זוגי?<div class='math-expression'>17, 23, 34, 41</div>", answer: "34", input: true },
+                { question: "כמה זה <span class='math-expression'>45 + 28</span>?", answer: "73", input: true },
+                { question: "מה התוצאה של <span class='math-expression'>7 × 8</span>?", answer: "56", input: true },
+                { question: "כמה זה <span class='math-expression'>120 ÷ 8</span>?", answer: "15", input: true },
+                { question: "איזה מספר חסר ברצף?<div class='math-expression'>5, 10, 20, 40, ?</div>", answer: "80", input: true },
+                { question: "מה שווה <span class='math-expression'>2/3 + 1/6</span>?", answer: "5/6", input: true },
+                { question: "כמה זה <span class='math-expression'>16 × 5</span>?", answer: "80", input: true },
+                { question: "מה התוצאה של <span class='math-expression'>150 - 67</span>?", answer: "83", input: true },
+                { question: "כמה זה <span class='math-expression'>72 ÷ 8</span>?", answer: "9", input: true },
+                { question: "איזה מספר אי-זוגי?<div class='math-expression'>24, 36, 45, 58</div>", answer: "45", input: true },
                 { question: "מה התוצאה של <span class='math-expression'>11 × 9</span>?", options: ["99", "89", "109", "79"], correct: 0 },
                 { question: "כמה זה <span class='math-expression'>63 + 29</span>?", options: ["92", "82", "102", "88"], correct: 0 },
                 { question: "מה התוצאה של <span class='math-expression'>96 ÷ 12</span>?", options: ["8", "6", "10", "7"], correct: 0 },
@@ -670,20 +677,28 @@
             
             document.getElementById('challenge-number').textContent = 
                 categoryNames[currentCategory] + ' - אתגר ' + (currentChallengeIndex + 1);
-            document.getElementById('challenge-question').textContent = challenge.question;
+            document.getElementById('challenge-question').innerHTML = challenge.question;
             
             var optionsContainer = document.getElementById('challenge-options');
             optionsContainer.innerHTML = '';
             
-            for (var i = 0; i < challenge.options.length; i++) {
-                var optionElement = document.createElement('div');
-                optionElement.className = 'option';
-                optionElement.textContent = challenge.options[i];
-                optionElement.setAttribute('data-index', i);
-                optionElement.onclick = function() {
-                    selectAnswer(parseInt(this.getAttribute('data-index')));
-                };
-                optionsContainer.appendChild(optionElement);
+            if (challenge.input) {
+                var inputElement = document.createElement("input");
+                inputElement.type = "text";
+                inputElement.id = "answer-input";
+                inputElement.className = "answer-input";
+                optionsContainer.appendChild(inputElement);
+            } else {
+                for (var i = 0; i < challenge.options.length; i++) {
+                    var optionElement = document.createElement("div");
+                    optionElement.className = "option";
+                    optionElement.textContent = challenge.options[i];
+                    optionElement.setAttribute("data-index", i);
+                    optionElement.onclick = function() {
+                        selectAnswer(parseInt(this.getAttribute("data-index")));
+                    };
+                    optionsContainer.appendChild(optionElement);
+                }
             }
             
             // Reset UI state
@@ -709,54 +724,58 @@
         }
 
         // Check answer
-        function checkAnswer() {
-            if (selectedAnswer === null) {
-                alert('אנא בחר תשובה');
-                return;
-            }
-            
-            var challenge = challenges[currentCategory][currentChallengeIndex];
-            var isCorrect = selectedAnswer === challenge.correct;
-            
-            // Update UI
-            var options = document.querySelectorAll('.option');
-            if (isCorrect) {
-                // Only highlight correct answer when user got it right
-                options[challenge.correct].classList.add('correct');
-            } else {
-                // Only highlight the wrong answer the user selected
-                options[selectedAnswer].classList.add('incorrect');
-            }
-            
-            // Show feedback
-            var feedback = document.getElementById('feedback');
-            var nextButton = document.getElementById('next-button');
-            feedback.classList.remove('hidden');
-            
-            if (isCorrect) {
-                feedback.textContent = '🎉 כל הכבוד! תשובה נכונה!';
-                feedback.className = 'feedback correct';
-                nextButton.textContent = 'האתגר הבא';
-                
-                // Mark challenge as completed
-                if (progress[currentCategory].indexOf(currentChallengeIndex) === -1) {
-                    progress[currentCategory].push(currentChallengeIndex);
-                    localStorage.setItem(currentCategory + '-progress', JSON.stringify(progress[currentCategory]));
-                }
-            } else {
-                feedback.textContent = '❌ לא נכון. נסה שוב!';
-                feedback.className = 'feedback incorrect';
-                nextButton.textContent = 'נסה שוב';
-            }
-            
-            // Hide submit button, show next button
-            document.getElementById('submit-button').classList.add('hidden');
-            nextButton.classList.remove('hidden');
-            
-            updateProgressDisplay();
-            checkCompletion();
-        }
 
+function checkAnswer() {
+    var challenge = challenges[currentCategory][currentChallengeIndex];
+    var isCorrect = false;
+    if (challenge.input) {
+        var userAnswer = document.getElementById('answer-input').value.trim();
+        if (userAnswer === '') {
+            alert('אנא הזן תשובה');
+            return;
+        }
+        isCorrect = userAnswer == challenge.answer;
+    } else {
+        if (selectedAnswer === null) {
+            alert('אנא בחר תשובה');
+            return;
+        }
+        isCorrect = selectedAnswer === challenge.correct;
+    }
+
+    if (!challenge.input) {
+        var options = document.querySelectorAll('.option');
+        if (isCorrect) {
+            options[challenge.correct].classList.add('correct');
+        } else {
+            options[selectedAnswer].classList.add('incorrect');
+        }
+    }
+
+    var feedback = document.getElementById('feedback');
+    var nextButton = document.getElementById('next-button');
+    feedback.classList.remove('hidden');
+
+    if (isCorrect) {
+        feedback.textContent = '🎉 כל הכבוד! תשובה נכונה!';
+        feedback.className = 'feedback correct';
+        nextButton.textContent = 'האתגר הבא';
+        if (progress[currentCategory].indexOf(currentChallengeIndex) === -1) {
+            progress[currentCategory].push(currentChallengeIndex);
+            localStorage.setItem(currentCategory + '-progress', JSON.stringify(progress[currentCategory]));
+        }
+    } else {
+        feedback.textContent = '❌ לא נכון. נסה שוב!';
+        feedback.className = 'feedback incorrect';
+        nextButton.textContent = 'נסה שוב';
+    }
+
+    document.getElementById('submit-button').classList.add('hidden');
+    nextButton.classList.remove('hidden');
+
+    updateProgressDisplay();
+    checkCompletion();
+}
         // Next challenge or retry
         function nextChallenge() {
             var nextButton = document.getElementById('next-button');


### PR DESCRIPTION
## Summary
- allow HTML inside challenge questions
- add text input mode for challenges and style `.answer-input`
- refactor `checkAnswer` for both inputs and options
- convert first 25 math challenges to use text input

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a74d48a4483268b7f77a36fb7fe93